### PR TITLE
Fix the python scripts for LSLib 1.19+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 scripts/logs
 scripts/output
 __pycache__
+/venv

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -33,6 +33,8 @@ def import_lslib(dll_path:Path)->bool:
     try:
         if dll_path.is_dir():
             dll_path = dll_path.joinpath("LSLib.dll")
+        import pythonnet
+        pythonnet.load('coreclr')
         import clr
         from System.Reflection import Assembly # type: ignore 
         Assembly.LoadFrom(str(dll_path.absolute()))

--- a/scripts/convert_loca.py
+++ b/scripts/convert_loca.py
@@ -35,6 +35,8 @@ if target_file.exists():
     lslib_dll:Path = args.divine.is_dir() and args.divine.joinpath("LSLib.dll") or args.divine.parent.joinpath("LSLib.dll")
 
     if lslib_dll.exists():
+        import pythonnet
+        pythonnet.load('coreclr')
         import clr
         from System.Reflection import Assembly # type: ignore 
         Assembly.LoadFrom(str(lslib_dll.absolute()))

--- a/scripts/convert_lsf.py
+++ b/scripts/convert_lsf.py
@@ -21,6 +21,8 @@ def on_progress(status, numerator, denominator):
 
 def run(lslib_dll:Path, input_file:Path, output_file:Path = None, recursive:bool = False, in_type:str = ".lsf", out_type:str = ".lsx"):
     if lslib_dll.exists():
+        import pythonnet
+        pythonnet.load('coreclr')
         import clr
         from System.Reflection import Assembly # type: ignore 
         Assembly.LoadFrom(str(lslib_dll.absolute()))

--- a/scripts/extract_database_entries.py
+++ b/scripts/extract_database_entries.py
@@ -128,6 +128,7 @@ if target_file.exists():
             helper = SavegameHelpers(str(target_file))
             story = helper.LoadStory()
             load_story(story)
+            helper.Dispose()
         elif target_file.suffix == ".osi":
             fs = FileStream(str(target_file.absolute()), FileMode.Open, FileAccess.Read, FileShare.Read)
             try:

--- a/scripts/extract_database_entries.py
+++ b/scripts/extract_database_entries.py
@@ -84,6 +84,8 @@ if target_file.exists():
         output_dir:Path = args.output
         output_dir.mkdir(exist_ok=True, parents=True)
         
+        import pythonnet
+        pythonnet.load('coreclr')
         import clr
         from System.Reflection import Assembly # type: ignore 
         Assembly.LoadFrom(str(lslib_dll.absolute()))
@@ -92,7 +94,7 @@ if target_file.exists():
 
         input_file:Path = args.file
 
-        from LSLib.LS import PackageReader # type: ignore 
+        from LSLib.LS.Save import SavegameHelpers # type: ignore 
         from LSLib.LS.Story import StoryReader # type: ignore 
         from System.IO import FileStream, FileMode, FileShare, FileAccess # type: ignore
         
@@ -103,9 +105,7 @@ if target_file.exists():
                 return f'"{value}"'
             return str(value)
                 
-        def load_story(stream):
-            reader = StoryReader()
-            story = reader.Read(stream)
+        def load_story(story):
             entries = []
             for db in story.Databases.Values:
                 owner = db.OwnerNode
@@ -119,25 +119,19 @@ if target_file.exists():
             output_file.write_text("\n".join(sorted(entries)))
             print(f"Saved database entries to {output_file}")
 
+        def load_story_from_stream(stream):
+            reader = StoryReader()
+            story = reader.Read(stream)
+            load_story(story)
+
         if target_file.suffix == ".lsv":
-            package_reader = PackageReader(str(target_file.absolute()))
-            package = package_reader.Read()
-            story_bin = None
-            for p in package.Files:
-                if str.lower(p.Name) == "storysave.bin":
-                    story_bin = p
-                    break
-            if story_bin is None:
-                raise Exception("Failed to find storysave.bin in save file.")
-            res_stream = story_bin.MakeStream()
-            try:
-                load_story(res_stream)
-            finally:
-                story_bin.ReleaseStream()            
+            helper = SavegameHelpers(str(target_file))
+            story = helper.LoadStory()
+            load_story(story)
         elif target_file.suffix == ".osi":
             fs = FileStream(str(target_file.absolute()), FileMode.Open, FileAccess.Read, FileShare.Read)
             try:
-                load_story(fs)
+                load_story_from_stream(fs)
             finally:
                 if fs != None: fs.Dispose()
     else:

--- a/scripts/extract_osiris.py
+++ b/scripts/extract_osiris.py
@@ -58,7 +58,6 @@ def run(target_file:Path, lslib_dll:Path, output_dir:Path = None, output_txt:boo
 
     import pythonnet
     pythonnet.load('coreclr')
-
     import clr
     from System.Reflection import Assembly # type: ignore 
     Assembly.LoadFrom(str(lslib_dll.absolute()))

--- a/scripts/extract_osiris.py
+++ b/scripts/extract_osiris.py
@@ -167,6 +167,7 @@ def run(target_file:Path, lslib_dll:Path, output_dir:Path = None, output_txt:boo
         helper = SavegameHelpers(str(target_file))
         story = helper.LoadStory()
         load_story(story)
+        helper.Dispose()
     elif target_file.suffix == ".json":
         with target_file.open("r", encoding="utf-8") as f:
             result = parse_data(f.read())

--- a/scripts/extract_osiris.py
+++ b/scripts/extract_osiris.py
@@ -56,16 +56,18 @@ def run(target_file:Path, lslib_dll:Path, output_dir:Path = None, output_txt:boo
     if output_dir:
         output_dir.mkdir(exist_ok=True, parents=True)
 
+    import pythonnet
+    pythonnet.load('coreclr')
+
     import clr
     from System.Reflection import Assembly # type: ignore 
     Assembly.LoadFrom(str(lslib_dll.absolute()))
     clr.AddReference("LSLib") # type: ignore 
     clr.AddReference("System") # type: ignore
 
-    from LSLib.LS import PackageReader, LSFReader # type: ignore 
     from LSLib.LS.Story import StoryDebugExportVisitor, StoryReader # type: ignore 
+    from LSLib.LS.Save import SavegameHelpers # type: ignore 
     from System.IO import FileStream, MemoryStream, FileMode, FileAccess, FileShare # type: ignore 
-    from System import Byte, Array # type: ignore 
     from System.Text import Encoding # type: ignore 
 
     def parse_data(result:str):
@@ -144,45 +146,28 @@ def run(target_file:Path, lslib_dll:Path, output_dir:Path = None, output_txt:boo
             output_dir.joinpath("OsirisQueries.txt").write_text(user_queries.export())
         return OsirisResults(events, calls, queries, user_queries, procs, databases)
 
-    def load_story(stream)->OsirisResults:
-        reader = StoryReader()
-        story = reader.Read(stream)
+    def load_story(story)->OsirisResults:
         data_stream = MemoryStream(4096)
         sev = StoryDebugExportVisitor(data_stream)
         sev.Visit(story)
         result = Encoding.UTF8.GetString(data_stream.ToArray())
         data_stream.Dispose()
         return parse_data(result)
+
+    def load_story_from_stream(stream)->OsirisResults:
+        reader = StoryReader()
+        story = reader.Read(stream)
+        return load_story(story)
         
     if target_file.suffix == ".osi":
         fs = FileStream(str(target_file.absolute()), FileMode.Open, FileAccess.Read, FileShare.Read)
-        result = load_story(fs)
+        result = load_story_from_stream(fs)
         fs.Dispose()
         return result
     elif target_file.suffix == ".lsv":
-        package_reader = PackageReader(str(target_file.absolute()))
-        package = package_reader.Read()
-        abstract_file_info = None
-        for p in package.Files:
-            if str.lower(p.Name) == "globals.lsf":
-                abstract_file_info = p
-                break
-        if abstract_file_info is None:
-            raise Exception("Failed to find globals.lsf in save file.")
-        res_stream = abstract_file_info.MakeStream()
-        resource = None
-        try:
-            res_reader = LSFReader(res_stream)
-            resource = res_reader.Read()
-            res_reader.Dispose()
-        finally:
-            abstract_file_info.ReleaseStream()
-        if resource:
-            story_node = resource.Regions["Story"].Children["Story"][0]
-            story_stream = MemoryStream(Array[Byte](story_node.Attributes["Story"].Value))
-            result = load_story(story_stream)
-            story_stream.Dispose()
-            return result
+        helper = SavegameHelpers(str(target_file))
+        story = helper.LoadStory()
+        load_story(story)
     elif target_file.suffix == ".json":
         with target_file.open("r", encoding="utf-8") as f:
             result = parse_data(f.read())

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,8 +1,8 @@
 alive_progress==2.4.0
-lxml==4.6.3
+lxml>=4.6.3
 numpy==1.22.3
 Pillow==10.0.0
 pyperclip==1.8.2
-pythonnet==3.0.1
+pythonnet>=3.0.1
 Send2Trash==1.8.0
 Wand==0.6.7


### PR DESCRIPTION
Fixes #4.
Should still work with LSLib 1.18 or before.

The requirements.txt changes mostly make it easier to grab all the dependencies for higher Python versions like 3.11