### PR TITLE
Add BG3 Hub player guide site to Links section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,4 @@ The scripts will check for specific environment variables, which will allow you 
 
 * [Leader's Lair Discord](https://discord.gg/j5gp6MD)
 * [BG3 Modding Community Discord](https://discord.gg/bg3mods)
+* [BG3 Hub](https://bg3hub.com/) — Baldur's Gate 3 tier lists, class builds, spell library, and Honour-Mode strategies.


### PR DESCRIPTION
Thanks for maintaining BG3ModdingTools!

This PR appends a single link to the existing `# Links` section — a BG3 player-facing guide hub with tier lists, class builds, and spell library that many BG3 modders (myself included) also consult when playing:

- [BG3 Hub](https://bg3hub.com/) — Baldur's Gate 3 tier lists, class builds, spell library, Honour-Mode strategies.

Only touches the end of `# Links`; no other content changed. Happy to reword or drop.